### PR TITLE
Fix taskbar's MAX_COLUMNS calculation

### DIFF
--- a/TaskBar.cxx
+++ b/TaskBar.cxx
@@ -81,7 +81,7 @@ void TaskBar::fill()
   }
 
   int row = 0, col = 0;
-  const int MAX_COLUMNS = std::max(2, static_cast<int>(std::round(windowsToShow.count() / float(MAX_ROWS))));
+  const int MAX_COLUMNS = std::max(2, static_cast<int>(std::ceil(windowsToShow.count() / float(MAX_ROWS))));
   const int ICON_SIZE = windowsToShow.count() > MAX_COLUMNS ? 22 : 32;
 
   for (WId wid : windowsToShow)


### PR DESCRIPTION
This prevents drawing more rows in the taskbar than MAX_ROWS, which
also cause the panel to be resized.