### PR TITLE
Prevent a crash when clicking on the blutooth icon

### DIFF
--- a/Bluetooth.cxx
+++ b/Bluetooth.cxx
@@ -76,7 +76,7 @@ QWidget *Bluetooth::getDetailsList()
 {
   if ( !dialog )
   {
-    dialog = new KCMultiDialog(this);
+    dialog = new KCMultiDialog(nullptr);
     dialog->setAttribute(Qt::WA_DeleteOnClose);
 
     dialog->addModule(KPluginMetaData("plasma/kcms/systemsettings/kcm_bluetooth"));


### PR DESCRIPTION
It seems liquidshell "crashes" each time you want to click on the bluetooth icon next to the systray and the new liquidshell opens above the previous liquidshell (at least if you have an 16:10 monitor), replacing this to nullptr when creating the new dialog prevents the "crash" and the bluetooth list opens as expected.